### PR TITLE
TEST: Fix Windows compatibility in ttlser tests (Line Endings)

### DIFF
--- a/ttlser/test/test_ttlser.py
+++ b/ttlser/test/test_ttlser.py
@@ -213,7 +213,9 @@ class TestRkt(Simple, TestTtlser):
 
 class TestDet(TestTtlser):
     def test_ser(self):
-        assert self.actual == self.good
+        actual = self.actual.replace(b'\r\n', b'\n')
+        good = self.good.replace(b'\r\n', b'\n')
+        assert actual == good
 
     def test_deterministic(self):
         assert self.deterministic()


### PR DESCRIPTION
**The Issue:**
The `TestDet.test_ser` test case was failing on Windows environments due to line-ending mismatches.
1. **AssertionError:** Windows file handling introduces Carriage Return + Line Feed (`\r\n`), while the expected output uses Unix-style (`\n`). This caused the byte streams to differ, failing the equality check.
2. **TypeError:** Attempting to fix this with standard string replacement failed because the serializer output is in **bytes**, not text strings.

**The Fix:**
I updated `ttlser/test/test_ttlser.py` to normalize line endings on the byte streams before assertion. This ensures the tests are platform-agnostic.

```python
# Normalize line endings (bytes) to fix Windows/Linux mismatch
actual = self.actual.replace(b'\r\n', b'\n')
good = self.good.replace(b'\r\n', b'\n')
assert actual == good
```

**Verification:**
**Environment:** Windows 11 / Python 3.11
**Before:** FAILED (errors=2)
**After:** Ran 15 tests ... OK
